### PR TITLE
Escaping email address in PD connector

### DIFF
--- a/scripts/pasha_pagerduty.coffee
+++ b/scripts/pasha_pagerduty.coffee
@@ -20,6 +20,7 @@
 # Node imports
 https = require('https')
 http = require('http')
+querystring = require('querystring')
 # Pasha imports
 scribeLog = require('../pasha_modules/scribe_log').scribeLog
 constant = require('../pasha_modules/constant').constant
@@ -140,7 +141,7 @@ getPDUserId = (email, onSuccess) ->
         httpsGetOptions = {
             hostname: pagerdutyHostName
             port: pagerdutyPort
-            path: "/api/v1/users/?query=#{email}"
+            path: "/api/v1/users/?query=#{querystring.escape(email)}"
             method: "GET"
             headers: {
                 'Authorization': auth

--- a/test/pasha_pagerduty_test.coffee
+++ b/test/pasha_pagerduty_test.coffee
@@ -170,7 +170,7 @@ describe 'alert command', () ->
 
     it 'should return the user\'s phone number', (done) ->
         pagerduty_get_users = nock("https://#{pagerdutyHostName}")
-            .get('/api/v1/users/?query=test@example.com')
+            .get('/api/v1/users/?query=test%2Bemail%40example.com')
             .reply(200, get_users_response)
 
         pagerduty_get_notification = nock("https://#{pagerdutyHostName}")
@@ -180,4 +180,4 @@ describe 'alert command', () ->
             assert.equal(response[0], 'Phone numbers: +36987654321,+36123456789')
             done()
         adapter.receive(new TextMessage(user,
-          "#{botName} phone test@example.com"))
+          "#{botName} phone test+email@example.com"))

--- a/test/pasha_twilio_test.coffee
+++ b/test/pasha_twilio_test.coffee
@@ -115,7 +115,7 @@ describe 'command registration', () ->
         get_notifications_response = require('../test_files/notifications.json')
         pagerdutyHostName = process.env.PAGERDUTY_HOST_NAME
         pagerduty_get_users = nock("https://#{pagerdutyHostName}")
-            .get('/api/v1/users/?query=test@example.com')
+            .get('/api/v1/users/?query=test%40example.com')
             .reply(200, get_users_response)
         pagerduty_get_notification = nock("https://#{pagerdutyHostName}")
             .get('/api/v1/users/PX123PD/notification_rules')


### PR DESCRIPTION
This change aims to fix an issue with PD connector when the email address we search for contains a +.
