### PR TITLE
Fixing pasha summon

### DIFF
--- a/scripts/pasha_twilio.coffee
+++ b/scripts/pasha_twilio.coffee
@@ -122,7 +122,7 @@ summonByName = (msg, robot) ->
         pashaState = util.getOrInitState(robot)
         u = util.getUser(name, msg.message.user.name, pashaState.users)
         if u
-          pagerduty.phone(u.email, (numbers) ->
+          pagerduty.phone(u.profile.email, (numbers) ->
               for number in numbers
                   phoneNumber = standardizePhoneNumber(number)
 

--- a/test/pasha_twilio_test.coffee
+++ b/test/pasha_twilio_test.coffee
@@ -104,7 +104,9 @@ describe 'command registration', () ->
         sinon = require('sinon')
         util = require('../pasha_modules/util')
         fakeUser = {
-            email: "test@example.com"
+            profile: {
+                email: "test@example.com"
+            }
         }
         getUserStub = sinon.stub().returns(fakeUser)
         util.getUser = getUserStub


### PR DESCRIPTION
Summon did not work because it logged 

```
[2016-04-15T08:41:01.782Z] user found: gergo.horanyi
[2016-04-15T08:41:01.807Z] getPDUserId: undefined
[2016-04-15T08:41:02.320Z] User email (undefined) is not set in PagerDuty
[2016-04-15T08:41:02.322Z] pagerduty response: {"users":[],"query":"undefined","active_account_users":120,"limit":25,"offset":0,"total":0}
```

The problem was, that it could not load the email address of the user since we migrated to Slack.
