### PR TITLE
Updating moment package version as it contains vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6.9.1"
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "hubot-scripts": "2.5.15",
     "hubot-slack": "3.4.2",
     "lodash": "^4.3.0",
-    "moment": "2.8.3",
+    "moment": "2.11.2",
     "nodemailer": "1.2.2",
     "path": "0.11.14",
     "request": "^2.69.0",


### PR DESCRIPTION
GitHub recommends to upgrade to at least version `2.11.2`