### PR TITLE
Don't add the same number twice to the numbers to call

### DIFF
--- a/scripts/pasha_pagerduty.coffee
+++ b/scripts/pasha_pagerduty.coffee
@@ -182,8 +182,9 @@ getPhoneNumberByEmail = (email, onSuccess) ->
                         if contact_method["type"] == "phone_contact_method" ||
                           contact_method["type"] == "sms_contact_method"
                             phone = "+#{contact_method["country_code"]}#{contact_method["address"]}"
-                            phone_numbers.push phone
-                            scribeLog "Found phone number in PagerDuty: #{email} => #{phone}"
+                            if phone not in phone_numbers  # Don't add the same number twice
+                                phone_numbers.push phone
+                                scribeLog "Found phone number in PagerDuty: #{email} => #{phone}"
                     onSuccess(phone_numbers)
         req.on "error", (e) ->
             scribeLog "Error: #{e.message}"

--- a/test_files/users.json
+++ b/test_files/users.json
@@ -66,6 +66,18 @@
           "blacklisted": false,
           "country_code": 36,
           "enabled": true
+        },
+        {
+          "id": "PFAAAA5",
+          "type": "phone_contact_method",
+          "summary": "Mobile",
+          "self": "https://api.pagerduty.com/users/PXXXXXW/contact_methods/PFAAAA5",
+          "html_url": null,
+          "label": "Mobile",
+          "address": "123456789",
+          "blacklisted": false,
+          "country_code": 36,
+          "enabled": true
         }
       ],
       "notification_rules": [


### PR DESCRIPTION
If someone has set up the same number for call & sms in PD, it would call/message the person twice
This should fix the issue and only call/message once

From these log lines we can see the duplication happens when finding the phone numbers:
```[2018-07-05T15:35:25.341Z] user found: david.guerrero
[2018-07-05T15:35:25.343Z] getPhoneNumberByEmail: david.guerrero@prezi.com
[2018-07-05T15:35:26.589Z] Found user in PagerDuty: david.guerrero@prezi.com => P9IGOKB
[2018-07-05T15:35:26.590Z] Found phone number in PagerDuty: david.guerrero@prezi.com => +33xxxxxxxxxx
[2018-07-05T15:35:26.590Z] Found phone number in PagerDuty: david.guerrero@prezi.com => +336xxxxxxxxxx
```
